### PR TITLE
[2.0.r1] KernelConfig: Remove appended dtb logic

### DIFF
--- a/KernelConfig.mk
+++ b/KernelConfig.mk
@@ -12,26 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-BUILD_KERNEL := false
-
-ifeq ($(BUILD_KERNEL),false)
+ifeq ($(BUILD_KERNEL), false)
 
 PLATFORM_KERNEL_OUT := $(KERNEL_PATH)/common-kernel/$(PRODUCT_PLATFORM)
 
-ifeq ($(BOARD_INCLUDE_DTB_IN_BOOTIMG), true)
-    # AOSP will concatenate all these into a single dtb.img
-    BOARD_PREBUILT_DTBIMAGE_DIR := $(PLATFORM_KERNEL_OUT)/dtb/
-else
-    dtb := -dtb
-endif
-
-ifeq ($(TARGET_NEEDS_DTBOIMAGE),true)
-    BOARD_PREBUILT_DTBOIMAGE := $(PLATFORM_KERNEL_OUT)/dtbo-$(TARGET_DEVICE).img
-endif
-
-LOCAL_KERNEL := $(PLATFORM_KERNEL_OUT)/kernel$(dtb)
+BOARD_PREBUILT_DTBIMAGE_DIR := $(PLATFORM_KERNEL_OUT)/dtb/
+BOARD_PREBUILT_DTBOIMAGE := $(PLATFORM_KERNEL_OUT)/dtbo-$(TARGET_DEVICE).img
 
 PRODUCT_COPY_FILES += \
-    $(LOCAL_KERNEL):kernel
+    $(PLATFORM_KERNEL_OUT)/kernel:kernel
 
 endif

--- a/build_shared.sh
+++ b/build_shared.sh
@@ -37,7 +37,7 @@ for platform in "${!PLATFORMS[@]}"; do
         make_cmd="make $BUILD_ARGS O=$KERNEL_TMP_PLATFORM"
 
         # Keep kernel tmp when building for a specific platform or when using keep tmp
-        [ "${keep_kernel_tmp:-}" != "true" ] && [ -z "${only_build_for:-}" ] && rm -rf "${KERNEL_TMP_PLATFORM}"
+        [ "${keep_kernel_tmp:-}" != "true" ] && rm -rf "${KERNEL_TMP_PLATFORM}"
         mkdir -p "${KERNEL_TMP_PLATFORM}"
 
         PLATFORM_KERNEL_OUT=$KERNEL_TOP/common-kernel/$platform

--- a/build_shared.sh
+++ b/build_shared.sh
@@ -73,12 +73,10 @@ for platform in "${!PLATFORMS[@]}"; do
         cp "$KERNEL_TMP_PLATFORM/arch/arm64/boot/Image${comp:-}${dtb:-}" "$PLATFORM_KERNEL_OUT/kernel${dtb:-}"
         check_error "Failed to copy kernel image to $PLATFORM_KERNEL_OUT/"
 
-        # If SOCDTB is specified, copy DTB files to the output directory.
-        if [ -n "${SOCDTB:-}" ]; then
-            mkdir -p "$PLATFORM_KERNEL_OUT/dtb/"
-            cp "$KERNEL_TMP_PLATFORM/arch/arm64/boot/dts/qcom/$SOCDTB" "$PLATFORM_KERNEL_OUT/dtb/"
-            check_error "Failed to copy $SOCDTB to $PLATFORM_KERNEL_OUT/dtb/"
-        fi
+        # Copy DTB files to the output directory.
+        mkdir -p "$PLATFORM_KERNEL_OUT/dtb/"
+        cp "$KERNEL_TMP_PLATFORM/arch/arm64/boot/dts/qcom/$SOCDTB" "$PLATFORM_KERNEL_OUT/dtb/"
+        check_error "Failed to copy $SOCDTB to $PLATFORM_KERNEL_OUT/dtb/"
 
         # Generate DTBO files for each device.
         for device in $DEVICES; do

--- a/build_shared.sh
+++ b/build_shared.sh
@@ -71,14 +71,21 @@ for platform in "${!PLATFORMS[@]}"; do
         check_error "Failed to copy kernel image to $PLATFORM_KERNEL_OUT/"
 
         # Copy DTB files to the output directory.
-        mkdir -p "$PLATFORM_KERNEL_OUT/dtb/"
-        cp "$KERNEL_TMP_PLATFORM/arch/arm64/boot/dts/qcom/$SOCDTB" "$PLATFORM_KERNEL_OUT/dtb/"
-        check_error "Failed to copy $SOCDTB to $PLATFORM_KERNEL_OUT/dtb/"
+        dtb="$KERNEL_TMP_PLATFORM/arch/arm64/boot/dts/qcom/$SOCDTB"
+        dtb_out="$PLATFORM_KERNEL_OUT/dtb/"
+        mkdir -p "$dtb_out"
+        cp "$dtb" "$dtb_out"
+        check_error "Failed to copy $SOCDTB to $dtb_out."
 
         # Generate DTBO files for each device.
         for device in $DEVICES; do
             dtbo="$KERNEL_TMP_PLATFORM/arch/arm64/boot/dts/qcom/${SOC}-${platform}-${device}_generic-overlay.dtbo"
             dtbo_out="$PLATFORM_KERNEL_OUT/dtbo-${device}.img"
+
+            # Validate the generated DTBO to ensure there are no errors before creating dtbo.img.
+            $UFDT_APPLY_OVERLAY "$dtb" "$dtbo" /dev/null
+            check_error "Failed to validate DTBO for device $device using $dtbo."
+
             echo "Creating $dtbo_out ..."
             $MKDTIMG create "$dtbo_out" $dtbo
             check_error "Failed to create DTBO for device $device using $dtbo"

--- a/build_shared.sh
+++ b/build_shared.sh
@@ -80,16 +80,14 @@ for platform in "${!PLATFORMS[@]}"; do
             check_error "Failed to copy $SOCDTB to $PLATFORM_KERNEL_OUT/dtb/"
         fi
 
-        # If DTBO creation is enabled, generate DTBO files for each device.
-        if [ "${DTBO:-}" = "true" ]; then
-            for device in $DEVICES; do
-                dtbo="$KERNEL_TMP_PLATFORM/arch/arm64/boot/dts/qcom/${SOC}-${platform}-${device}_generic-overlay.dtbo"
-                dtbo_out="$PLATFORM_KERNEL_OUT/dtbo-${device}.img"
-                echo "Creating $dtbo_out ..."
-                $MKDTIMG create "$dtbo_out" $dtbo
-                check_error "Failed to create DTBO for device $device using $dtbo"
-            done
-        fi
+        # Generate DTBO files for each device.
+        for device in $DEVICES; do
+            dtbo="$KERNEL_TMP_PLATFORM/arch/arm64/boot/dts/qcom/${SOC}-${platform}-${device}_generic-overlay.dtbo"
+            dtbo_out="$PLATFORM_KERNEL_OUT/dtbo-${device}.img"
+            echo "Creating $dtbo_out ..."
+            $MKDTIMG create "$dtbo_out" $dtbo
+            check_error "Failed to create DTBO for device $device using $dtbo"
+        done
 
         # Normalize permissions. Set all files under $PLATFORM_KERNEL_OUT to 644.
         # Some files, such as the kernel image, may be marked executable (755) by

--- a/build_shared.sh
+++ b/build_shared.sh
@@ -26,9 +26,6 @@ for platform in "${!PLATFORMS[@]}"; do
         if [ "${COMPRESSED:-}" = "true" ]; then
             comp=".gz"
         fi
-        if [ -z "${SOCDTB:-}" ]; then
-            dtb="-dtb"
-        fi
 
         # Set KERNEL_TMP_PLATFORM to either the value of build_directory (if set)
         # or default to $KERNEL_TMP/${platform} if build_directory is unset or empty.
@@ -70,7 +67,7 @@ for platform in "${!PLATFORMS[@]}"; do
         check_error "Build failed. See $KERNEL_TMP_PLATFORM/build.log for details."
 
         echo "Copying new kernel image ..."
-        cp "$KERNEL_TMP_PLATFORM/arch/arm64/boot/Image${comp:-}${dtb:-}" "$PLATFORM_KERNEL_OUT/kernel${dtb:-}"
+        cp "$KERNEL_TMP_PLATFORM/arch/arm64/boot/Image${comp:-}" "$PLATFORM_KERNEL_OUT/kernel"
         check_error "Failed to copy kernel image to $PLATFORM_KERNEL_OUT/"
 
         # Copy DTB files to the output directory.

--- a/build_shared_vars.sh
+++ b/build_shared_vars.sh
@@ -181,9 +181,7 @@ if [ ! -x "$UFDT_APPLY_OVERLAY" ]; then
 fi
 
 KERNEL_TOP=$ANDROID_ROOT/kernel/sony/msm-5.15
-# $KERNEL_TMP sub dir per script
-c=${0##*-}
-KERNEL_TMP=${build_directory:-$ANDROID_ROOT/out/kernel-5.15/${c%%.sh}}
+KERNEL_TMP=${build_directory:-$ANDROID_ROOT/out/kernel-5.15}
 
 # -------------------------------------------------------------------------
 # Associative Array: PLATFORMS

--- a/build_shared_vars.sh
+++ b/build_shared_vars.sh
@@ -172,12 +172,13 @@ if [ ! -x "$MKDTIMG" ]; then
     exit 1
 fi
 
-# UFDT apply overlay tool. Optional
+# UFDT apply overlay tool
 # ufdt_apply_overlay verifies that the device tree overlay (DTO) can be applied to
 # the base device tree blob (DTB) without errors, ensuring correct configuration.
 UFDT_APPLY_OVERLAY=$ANDROID_ROOT/prebuilts/misc/linux-x86/libufdt/ufdt_apply_overlay
 if [ ! -x "$UFDT_APPLY_OVERLAY" ]; then
-    UFDT_APPLY_OVERLAY=""
+    echo "Error: No ufdt_apply_overlay executable found. Please check your Android root."
+    exit 1
 fi
 
 KERNEL_TOP=$ANDROID_ROOT/kernel/sony/msm-5.15

--- a/build_shared_vars.sh
+++ b/build_shared_vars.sh
@@ -197,7 +197,6 @@ KERNEL_TMP=${build_directory:-$ANDROID_ROOT/out/kernel-5.15/${c%%.sh}}
 #
 #   These variables may include:
 #     - COMPRESSED: Whether the kernel image should be compressed (true/false)
-#     - DTBO:       Whether a DTBO image should be generated (true/false)
 #     - SOC:        The SoC identifier used by the platform
 #     - SOCDTB:     The base SoC .dtb filename
 #     - DEVICES:    List of device identifiers belonging to the platform
@@ -221,14 +220,12 @@ KERNEL_TMP=${build_directory:-$ANDROID_ROOT/out/kernel-5.15/${c%%.sh}}
 declare -A PLATFORMS=(
     ['nagara']="
         COMPRESSED=false
-        DTBO=true
         SOC='waipio'
         SOCDTB='waipio-v2.dtb'
         DEVICES='pdx223 pdx224'
     "
     ['yodo']="
         COMPRESSED=false
-        DTBO=true
         SOC='kalama'
         SOCDTB='kalama-v2.dtb'
         DEVICES='pdx234 pdx237'


### PR DESCRIPTION
All platforms using this kernel don't use the appended DTB
and all use DTBO, so there's no point in having this logic.
This change will allow us to get rid of unnecessary build flags.

Also sync the script with the upcoming 6.6 version, which includes a set of new changes.